### PR TITLE
fix: Update tsconfig.node.json to reference vite.config.js

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -21,5 +21,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.js"]
 }


### PR DESCRIPTION
- Update include path from vite.config.ts to vite.config.js
- Fix TypeScript build error in GitHub Actions
- Resolve 'No inputs were found' error during build process
- Ensure TypeScript compilation works with JavaScript Vite config

This should fix the build:docs command in GitHub Actions.