### PR TITLE
fix: Remove vite.config.js from TypeScript compilation

### DIFF
--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -21,5 +21,5 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["vite.config.js"]
+  "include": []
 }


### PR DESCRIPTION
- Set tsconfig.node.json include to empty array
- Since vite.config.js is JavaScript, it doesn't need TypeScript compilation
- tsconfig.app.json handles the src directory TypeScript files
- Fixes 'No inputs were found' error in GitHub Actions build

This should resolve the build:docs command error.