### PR TITLE
fix: Use secrets context instead of vars for environment variables

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -33,9 +33,9 @@ jobs:
     - name: Build documentation site
       run: npm run build:docs
       env:
-        VITE_GA_MEASUREMENT_ID: ${{ vars.VITE_GA_MEASUREMENT_ID }}
-        VITE_AMPLITUDE_API_KEY: ${{ vars.VITE_AMPLITUDE_API_KEY }}
-        VITE_HOTJAR_SITE_ID: ${{ vars.VITE_HOTJAR_SITE_ID }}
+        VITE_GA_MEASUREMENT_ID: ${{ secrets.VITE_GA_MEASUREMENT_ID }}
+        VITE_AMPLITUDE_API_KEY: ${{ secrets.VITE_AMPLITUDE_API_KEY }}
+        VITE_HOTJAR_SITE_ID: ${{ secrets.VITE_HOTJAR_SITE_ID }}
       
     - name: Setup Pages
       uses: actions/configure-pages@v4


### PR DESCRIPTION
- Change from vars.VITE_* to secrets.VITE_* in GitHub Actions workflow
- GitHub Actions requires secrets context for environment variables
- Repository variables need to be moved to Repository Secrets

Next step: Move environment variables from Repository Variables to Repository Secrets in GitHub settings.